### PR TITLE
Add simple Node.js LINE OA backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# LINE OA Backend
+
+This repository includes a simple Node.js backend that connects to the LINE Official Account API.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Create a `.env` file or export the following environment variables:
+
+- `LINE_CHANNEL_ACCESS_TOKEN` – your channel access token
+- `LINE_CHANNEL_SECRET` – your channel secret
+- `PORT` *(optional)* – port to run the server (defaults to 3000)
+
+3. Start the server:
+
+```bash
+npm start
+```
+
+The server exposes two endpoints:
+
+- `POST /webhook` – handles incoming webhook events from LINE.
+- `GET /send/:userId?message=Hello` – sends a push message to a user.
+
+Make sure your LINE OA webhook URL points to `/webhook` on this server.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "line-bot-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "@line/bot-sdk": "^8.4.0",
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const line = require('@line/bot-sdk');
+
+const config = {
+  channelAccessToken: process.env.LINE_CHANNEL_ACCESS_TOKEN,
+  channelSecret: process.env.LINE_CHANNEL_SECRET
+};
+
+if (!config.channelAccessToken || !config.channelSecret) {
+  console.error('LINE_CHANNEL_ACCESS_TOKEN and LINE_CHANNEL_SECRET must be set');
+  process.exit(1);
+}
+
+const client = new line.Client(config);
+const app = express();
+
+app.use('/webhook', line.middleware(config));
+
+app.post('/webhook', (req, res) => {
+  Promise.all(req.body.events.map(handleEvent))
+    .then((result) => res.json(result))
+    .catch((err) => {
+      console.error(err);
+      res.status(500).end();
+    });
+});
+
+function handleEvent(event) {
+  if (event.type !== 'message' || event.message.type !== 'text') {
+    return Promise.resolve(null);
+  }
+  const echo = { type: 'text', text: `You said: ${event.message.text}` };
+  return client.replyMessage(event.replyToken, echo);
+}
+
+app.get('/send/:userId', async (req, res) => {
+  const userId = req.params.userId;
+  const message = req.query.message || 'Hello from LINE bot';
+  try {
+    await client.pushMessage(userId, { type: 'text', text: message });
+    res.send('Message sent');
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Error sending message');
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add a Node.js server connecting to LINE Official Account API
- provide instructions in README
- ignore node_modules

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_6867975de1dc83338d0c2a0d1028080e